### PR TITLE
Connection descriptions feature

### DIFF
--- a/src/core/data/game.xml
+++ b/src/core/data/game.xml
@@ -509,22 +509,29 @@ He's white, transparent and floating six or seven feet off the ground.  He smile
    <rooms>
 
       <!-- every room MUST HAVE a UNIQUE name.  One room MUST have the name
-           "start," which is where the player will start when the game begins.
-       -->
+           "start," which is where the player will start when the game begins. -->
       <room name="start">
 
          <!-- user will see the room's title above its description -->
          <title>The Palace</title>
 
-         <!-- user will see the room's description when they enter -->
+         <!-- user will see the room's description when they enter. If you want
+              more control over how you describe connections between rooms, you
+              can make those descriptions part of the room's main description,
+              as is done here when we describe the "sideways" connection, but by
+              doing so, you sacrifice the engine's ability to manage those
+              descriptions should a connection later changed or removed. -->
          <description>
 You're standing in the middle of a sprawling white marble castle, the walls lined with portraits of long deceased ancestors of some forgotten king.  Servants are bustling about, rushing around with steaming plates of meats and cooked vegetables, rushing in and out of rooms to serve princes and heads of state. Legend has it that going sideways can transport you to a strange and mystical land.
-
-To the north, you see a dark hole in the wall big enough to walk through.
          </description>
 
-         <!-- names of the rooms "north" and "sideways" of this one -->
-         <north>cave</north>
+         <!-- names of the rooms "north" and "sideways" of this one. Each
+              connection is allowed an optional description, which will be
+              rendered in its own paragraph whenever the room is observed by a
+              player. The advantage of describing connections this way is that
+              the engine can better handle the way a room is described when a
+              connection is changed or removed mid-game. -->
+         <north description="To the north, you see a dark hole in the wall big enough to walk through.">cave</north>
          <sideways>mysticalhall</sideways>
 
          <events>
@@ -567,11 +574,9 @@ To the north, you see a dark hole in the wall big enough to walk through.
 
          <description>
 You find yourself in a mystical hall that seems to extend from one horizon to the next. The room is filled with clouds, and if you strain your ears carefully, you think you might hear the sound of an angelic choir.
-
-You can't say for sure, but you suspect that going sideways will return you to the castle.
          </description>
 
-         <sideways>start</sideways>
+         <sideways description="You can't say for sure, but you suspect that going sideways will return you to the castle.">start</sideways>
 
       </room>
 
@@ -580,15 +585,15 @@ You can't say for sure, but you suspect that going sideways will return you to t
          <title>The Cave</title>
 
          <description>
-You're in a dark musty cave.  You see a light some ways off to the south.  To the west, you spy a large dark chamber of some sort.
+You're in a dank and musty cave.
          </description>
 
          <!-- Since this room is north of "start," start is south of here.  You
               can specify one way movements by not placing this line here (maybe,
               for example, the user got shut behind a trap door?)
          -->
-         <west>chamber</west>
-         <south>start</south>
+         <west description="To the west, you spy a dark chamber.">chamber</west>
+         <south description="To the south, you see a light.">start</south>
 
          <contains>
             <creature>casper</creature>
@@ -601,14 +606,14 @@ You're in a dark musty cave.  You see a light some ways off to the south.  To th
          <title>Dark Chamber</title>
 
          <description>
-You find yourself in a dark secluded chamber.  It's dank, musty and generally icky poo-pooos.  Be careful.  There may be nasty things waiting for you here!
+You find yourself in a dark secluded chamber. It's dank, musty, and generally icky poo-pooos. Be careful. There may be nasty things waiting for you here!
          </description>
 
          <!-- The room's short description, which the player sees everytime
               they enter the room after the first time -->
          <short>It's dark.  Careful!</short>
 
-         <east>cave</east>
+         <east description="To the east, you see the entrance to a cave.">cave</east>
 
          <contains>
             <creature>trogdor</creature>

--- a/src/core/entities/room.cpp
+++ b/src/core/entities/room.cpp
@@ -60,8 +60,20 @@ namespace trogdor::entity {
    void Room::displayConnections(Being *observer, bool displayFull) {
 
       if (!observedBy(observer->getShared()) || displayFull) {
+
+         std::vector<std::string> toRemove;
+
          for (const auto &description: connectionDescriptions) {
-            observer->out("display") << std::endl << description.second << std::endl;
+            if (getConnection(description.first)) {
+               observer->out("display") << std::endl << description.second << std::endl;
+            } else {
+               toRemove.push_back(description.first);
+            }
+         }
+
+         // If we encountered any stale connection descriptions, remove them.
+         for (const auto &badConnection: toRemove) {
+            connectionDescriptions[badConnection].erase();
          }
       }
    }

--- a/src/core/entities/room.cpp
+++ b/src/core/entities/room.cpp
@@ -49,6 +49,16 @@ namespace trogdor::entity {
             }
          }
 
+         if (data.get("connectionDescriptions")) {
+
+            std::shared_ptr<serial::Serializable> serializedConnectionDescriptions =
+               std::get<std::shared_ptr<serial::Serializable>>(*data.get("connectionDescriptions"));
+
+            for (const auto &description: serializedConnectionDescriptions->getAll()) {
+               connectionDescriptions[description.first] = std::get<std::string>(description.second);
+            }
+         }
+
          return true;
       }));
 
@@ -94,6 +104,7 @@ namespace trogdor::entity {
 
       std::shared_ptr<serial::Serializable> data = Place::serialize();
       std::shared_ptr<serial::Serializable> serializedConnections = std::make_shared<serial::Serializable>();
+      std::shared_ptr<serial::Serializable> serializedConnectionDescriptions = std::make_shared<serial::Serializable>();
 
       for (const auto &connection: connections) {
          if (const auto &connectedRoom = connection.second.lock()) {
@@ -101,7 +112,15 @@ namespace trogdor::entity {
          }
       }
 
+      for (const auto &description: connectionDescriptions) {
+         if (getConnection(description.first)) {
+            serializedConnectionDescriptions->set(description.first, description.second);
+         }
+      }
+
       data->set("connections", serializedConnections);
+      data->set("connectionDescriptions", serializedConnectionDescriptions);
+
       return data;
    }
 

--- a/src/core/entities/room.cpp
+++ b/src/core/entities/room.cpp
@@ -1,5 +1,6 @@
 #include <trogdor/game.h>
 #include <trogdor/entities/room.h>
+#include <trogdor/entities/being.h>
 #include <trogdor/exception/validationexception.h>
 
 
@@ -52,6 +53,27 @@ namespace trogdor::entity {
       }));
 
       types.push_back(ENTITY_ROOM);
+   }
+
+   /****************************************************************************/
+
+   void Room::displayConnections(Being *observer, bool displayFull) {
+
+      if (!observedBy(observer->getShared()) || displayFull) {
+         for (const auto &description: connectionDescriptions) {
+            observer->out("display") << std::endl << description.second << std::endl;
+         }
+      }
+   }
+
+   /****************************************************************************/
+
+   void Room::display(Being *observer, bool displayFull) {
+
+      displayPlace(observer, displayFull);
+      displayConnections(observer, displayFull);
+      displayResources(observer);
+      displayThings(observer);
    }
 
    /***************************************************************************/
@@ -112,11 +134,21 @@ namespace trogdor::entity {
 
    /**************************************************************************/
 
-   void Room::setConnection(std::string direction, const std::shared_ptr<Room> &connectTo) {
+   void Room::setConnection(
+      std::string direction,
+      const std::shared_ptr<Room> &connectTo,
+      std::optional<std::string> description
+   ) {
 
       if (game->getVocabulary().isDirection(direction)) {
+
          mutex.lock();
          connections[direction] = connectTo;
+
+         if (description) {
+            connectionDescriptions[direction] = *description;
+         }
+
          mutex.unlock();
       }
 

--- a/src/core/game.cpp
+++ b/src/core/game.cpp
@@ -458,6 +458,12 @@ namespace trogdor {
          return false;
       }
 
+      // TODO: if entity is a resource and a Place or Being has any of it,
+      // removal should fail until the resource is removed from them all
+
+      // TODO: if entity is a Place and that place contains one or more Things
+      // or Resources, removal should fail until those things are removed
+
       mutex.lock();
 
       switch (entities[name]->getType()) {

--- a/src/core/include/trogdor/entities/room.h
+++ b/src/core/include/trogdor/entities/room.h
@@ -19,8 +19,37 @@ namespace trogdor::entity {
 
       protected:
 
-         // maps directions to connected rooms
+         // Maps directions to connected rooms
          std::unordered_map<std::string, std::weak_ptr<Room>> connections;
+
+         // Maps directions to optional connection descriptions
+         // TODO: should I allow these to be ordered?
+         std::unordered_map<std::string, std::string> connectionDescriptions;
+
+         /*
+            Outputs a description of each connection (if a description exists.)
+
+            Input:
+               Being observing the Place (Being *)
+               Whether or not to always show the long description
+
+            Output:
+               (none)
+         */
+         void displayConnections(Being *observer, bool displayFull = false);
+
+         /*
+            Overrides Place::display(). It does mostly the same thing, except
+            it also displays connection descriptions before Resources and Things.
+
+            Input:
+               Being observing the Room
+               Whether or not to always show the long description
+
+            Output:
+               (none)
+         */
+         virtual void display(Being *observer, bool displayFull = false);
 
       public:
 
@@ -153,13 +182,15 @@ namespace trogdor::entity {
             Connects Room to another Room at the specified direction.
 
             Input:
-               Direction where the connection is made (string)
+               Direction where the connection is made (std::string)
                Room direction connects to (const std::shared_ptr<Room> &)
+               Optional description (std::optional<std::string>)
 
             Output:
                (none)
          */
-         void setConnection(std::string direction, const std::shared_ptr<Room> &connectTo);
+         void setConnection(std::string direction, const std::shared_ptr<Room> &connectTo,
+         std::optional<std::string> description = std::nullopt);
    };
 }
 

--- a/src/core/include/trogdor/parser/parser.h
+++ b/src/core/include/trogdor/parser/parser.h
@@ -322,6 +322,7 @@ namespace trogdor {
                Source room (std::string)
                Room source connects to (std::string)
                Direction where connection should be made (std::string)
+               An optional description of the connection (std::optional<std::string>)
                Current line number in the source being parsed (int)
 
             Output:
@@ -329,7 +330,7 @@ namespace trogdor {
          */
          std::shared_ptr<ASTOperationNode> ASTConnectRooms(std::string targetType,
          std::string sourceRoomOrClass, std::string connectTo, std::string direction,
-         int lineNumber = 0);
+         std::optional<std::string> description, int lineNumber = 0);
 
          /*
             Returns an AST subtree representing an allocateResource operation

--- a/src/core/include/trogdor/parser/parsers/xmlparser.h
+++ b/src/core/include/trogdor/parser/parsers/xmlparser.h
@@ -378,13 +378,16 @@ namespace trogdor {
                direction (std::string)
                Name of room where the connection should be made (std::string)
                Name of room that we want to connect to (std::string)
+               An optional connection description to render when describing the
+                  room (std::optional<std::string>)
                Type of thing we're parsing--"entity" or "class" (std::string)
 
             Output:
                (none)
          */
          void parseRoomConnection(std::string direction, std::string roomName,
-         std::string connectTo, std::string targetType);
+         std::string connectTo, std::optional<std::string> description,
+         std::string targetType);
 
          /*
             Parses a Room's version of the <contains> section.

--- a/src/core/instantiator/instantiator.cpp
+++ b/src/core/instantiator/instantiator.cpp
@@ -764,7 +764,7 @@ namespace trogdor {
       // Validation
       preOperations[CONNECT_ROOMS] = [this](const std::shared_ptr<ASTOperationNode> &operation) {
 
-         assertValidASTArguments(operation, 4);
+         assertValidASTArguments(operation, 4, 5);
 
          std::string targetType = operation->getChildren()[0]->getValue();
          std::string sourceRoomOrClass = operation->getChildren()[1]->getValue();

--- a/src/core/instantiator/instantiators/runtime.cpp
+++ b/src/core/instantiator/instantiators/runtime.cpp
@@ -577,6 +577,7 @@ namespace trogdor {
          std::string targetType = operation->getChildren()[0]->getValue();
          std::string sourceRoomOrClass = operation->getChildren()[1]->getValue();
          std::string direction = operation->getChildren()[3]->getValue();
+         std::optional<std::string> description = std::nullopt;
 
          if (0 == targetType.compare("entity")) {
             room = game->getRoom(sourceRoomOrClass).get();
@@ -586,7 +587,11 @@ namespace trogdor {
             room = dynamic_cast<Room *>(typeClasses[sourceRoomOrClass].get());
          }
 
-         room->setConnection(direction, connectToRoom);
+         if (5 == operation->size()) {
+            description = operation->getChildren()[4]->getValue();
+         }
+
+         room->setConnection(direction, connectToRoom, description);
       });
 
       /**********/

--- a/src/core/parser/parser.cpp
+++ b/src/core/parser/parser.cpp
@@ -554,7 +554,7 @@ namespace trogdor {
 
    std::shared_ptr<ASTOperationNode> Parser::ASTConnectRooms(std::string targetType,
    std::string sourceRoomOrClass, std::string connectTo, std::string direction,
-   int lineNumber) {
+   std::optional<std::string> description, int lineNumber) {
 
       auto operation = std::make_shared<ASTOperationNode>(
          CONNECT_ROOMS,
@@ -584,6 +584,14 @@ namespace trogdor {
          AST_VALUE,
          lineNumber
       ));
+
+      if (description) {
+         operation->appendChild(std::make_shared<ASTNode>(
+            *description,
+            AST_VALUE,
+            lineNumber
+         ));
+      }
 
       return operation;
    }

--- a/src/core/parser/parsers/inform7parser.cpp
+++ b/src/core/parser/parsers/inform7parser.cpp
@@ -2127,6 +2127,7 @@ namespace trogdor {
                   0 == startRoomName.compare(entityToConnect.first) ? "start" : entityToConnect.first,
                   0 == startRoomName.compare(connectTo) ? "start" : connectTo,
                   direction,
+                  std::nullopt,
                   std::get<2>(connection.second)
                ));
             }

--- a/src/core/parser/parsers/xmlparser.cpp
+++ b/src/core/parser/parsers/xmlparser.cpp
@@ -1177,8 +1177,9 @@ namespace trogdor {
             vocabulary.isDirection(tag) ||
             customDirections.end() != customDirections.find(tag)
          ) {
+            std::optional<std::string> description = getOptionalAttribute("description");
             std::string connection = parseString();
-            parseRoomConnection(tag, name, connection, targetType);
+            parseRoomConnection(tag, name, connection, description, targetType);
          }
 
          else if (0 == tag.compare("contains")) {
@@ -1235,7 +1236,7 @@ namespace trogdor {
    /***************************************************************************/
 
    void XMLParser::parseRoomConnection(std::string direction, std::string roomName,
-   std::string connectTo, std::string targetType) {
+   std::string connectTo, std::optional<std::string> description, std::string targetType) {
 
       setUnresolvedEntityReference(
          connectTo,
@@ -1249,6 +1250,7 @@ namespace trogdor {
          roomName,
          connectTo,
          direction,
+         description,
          xmlTextReaderGetParserLineNumber(reader)
       ));
 


### PR DESCRIPTION
Adds the ability to write descriptions for individual room connections that get rendered in their own paragraph whenever a room is fully displayed.