### PR TITLE
Remove entity

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 ### Changed
 
 - Reimplemented the items in a Being's inventory using std::weak_ptr. Any code that calls Being::getInventoryObjects() or Being::getInventoryObjectsByName() will have to be adjusted to take this change into account.
+- Game::removeEntity() now enforces a more complete set of rules and no longer returns a boolean value (instead, it throws an exception if anything goes wrong.)
 
 ### Fixed
 


### PR DESCRIPTION
Game::removeEntity() no longer returns a boolean value (instead, it throws an exception if anything goes wrong) and now enforces a broader and more complete set of rules.