### PR TITLE
Update parser.h

### DIFF
--- a/src/core/include/trogdor/parser/parser.h
+++ b/src/core/include/trogdor/parser/parser.h
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <string>
+#include <optional>
 
 #include <trogdor/vocabulary.h>
 #include <trogdor/iostream/trogerr.h>


### PR DESCRIPTION
Add missing include statement (I'm not sure why this compiles in some environments and not others, but this fixed a build error for me on Ubuntu 22.04)